### PR TITLE
docs(agents): clarify shared coding standards usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,7 @@ This repository is a small GitHub Pages site built with Jekyll.
 
 ## Shared skill
 
-Use the shared `coding-standards` skill from `./bin/skills/coding-standards`
-for cross-repository coding, review, testing, documentation, and PR
-conventions. Treat this `AGENTS.md` as the repo-specific companion to that
+Use the shared `coding-standards` skill from `bin/skills/coding-standards` for code changes, bug fixes, refactors, reviews, tests, linting, documentation, PR summaries, commits, Makefile changes, CI validation, and verification. Treat this `AGENTS.md` as the repo-specific companion to that
 skill.
 
 ## Edit here


### PR DESCRIPTION
## What

Clarified the shared `coding-standards` skill guidance in `AGENTS.md`, including the repo-relative path and the types of work it applies to.

## Why

Makes the repo-local agent instructions more explicit for code changes, reviews, tests, linting, documentation, PR summaries, commits, CI validation, and verification.

## Testing

Not run; summary-only request for a documentation change.