### PR TITLE
feat(site): publish correct metadata and crawl rules

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,10 @@ title: "Alejandro Falkowski"
 # Exclude internal repository docs and vendored dependencies from the generated site output
 exclude:
   - AGENTS.md
+  - LICENSE
+  - Makefile
+  - README.md
+  - bin
   - vendor
 
 # Switch from pages-themes/hacker to Beautiful Jekyll
@@ -10,6 +14,13 @@ remote_theme: daattali/beautiful-jekyll@6.0.1
 
 plugins:
   - jekyll-remote-theme
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      head-extra:
+        - head-custom.html
 
 # Basic defaults expected by Beautiful Jekyll (safe to tweak later)
 navbar-links:

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,5 +1,5 @@
-<link rel="shortcut icon" type="image/png" href="assets/images/favicon.ico">
-<link rel="apple-touch-icon" sizes="180x180" href="assets/images/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="assets/images/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon-16x16.png">
-<link rel="manifest" href="assets/images/site.webmanifest">
+<link rel="shortcut icon" type="image/png" href="{{ '/assets/images/favicon.ico' | relative_url }}">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/images/favicon-32x32.png' | relative_url }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/images/favicon-16x16.png' | relative_url }}">
+<link rel="manifest" href="{{ '/assets/images/site.webmanifest' | relative_url }}">

--- a/assets/images/site.webmanifest
+++ b/assets/images/site.webmanifest
@@ -1,1 +1,3 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+---
+---
+{"name":"Alejandro Falkowski","short_name":"Alejandro","icons":[{"src":"{{ '/assets/images/android-chrome-192x192.png' | relative_url }}","sizes":"192x192","type":"image/png"},{"src":"{{ '/assets/images/android-chrome-512x512.png' | relative_url }}","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+share-description: "Software leader focused on building reliable, high-performing systems and teams."
 ---
 
 {% include_relative README.md %}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## What
- wire Beautiful Jekyll's head-extra hook to include favicon and manifest tags
- add explicit homepage share metadata and fix manifest icon paths
- keep source-only repository files out of the generated site and publish a minimal robots.txt

## Why
- prevent rendered social/search descriptions from showing Liquid include text
- make browser icons and the web manifest resolve to built assets
- avoid exposing repository internals as standalone generated pages while keeping crawlers allowed

## Testing
- make lint
- bundle exec jekyll build
- inspected generated _site/index.html, _site/assets/images/site.webmanifest, and _site/robots.txt

AI-assisted-by: [Codex](https://openai.com/codex/)
