### PR TITLE
feat(readme): separate homepage copy from project docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,9 @@ matching skill for the task.
 
 ## Edit here
 
-- `README.md`: primary page content.
-- `index.md`: home page wrapper; includes `README.md` with `{% include_relative %}`.
+- `README.md`: repository documentation.
+- `_includes/home.md`: primary page content.
+- `index.md`: home page wrapper; includes `_includes/home.md`.
 - `_config.yml`: Jekyll config, remote theme, plugin, navbar, social links, and exclusions.
 - `_includes/head-custom.html`: favicon and manifest links injected into the page `<head>`.
 - `assets/css/main.scss`: stylesheet entrypoint.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,24 @@
 [![CircleCI](https://circleci.com/gh/alexfalkowski/alexfalkowski.github.io.svg?style=shield)](https://circleci.com/gh/alexfalkowski/alexfalkowski.github.io)
 [![Stability: Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
 
-# Welcome
+# alexfalkowski.github.io
 
-I’m a software leader focused on building reliable, high-performing systems and teams. I enjoy taking products from idea to production, improving existing platforms, and collaborating closely with stakeholders to ship measurable outcomes.
+Personal GitHub Pages site for [www.afalkowski.com](https://www.afalkowski.com).
 
-## Find me online
+The site is built with Jekyll and the Beautiful Jekyll remote theme. Public homepage content lives in `_includes/home.md` and is rendered by `index.md`.
 
-- [CV](https://docs.google.com/document/d/1Nd9rfwKs_j5rcImtY17WhFj4LDfnHSRY_lgnh5cCjeE/edit?usp=sharing)
-- [LinkedIn](https://www.linkedin.com/in/alejandro-falkowski/)
-- [GitHub](https://github.com/alexfalkowski)
-- [Service status](https://stats.uptimerobot.com/GcWygK84MD)
-- [Blog](https://alejandrofalkowski.substack.com/)
-- [Manager README](https://docs.google.com/document/d/1IR8zKf5e323wEFd8skONK2ruAHWHethVwaXaUcf-NUU/edit?usp=sharing)
+## Development
 
-## Interests / Focus Areas
+- `make`: show available targets
+- `make dep`: install Ruby dependencies into `vendor/bundle`
+- `make serve`: run the local Jekyll server
+- `make lint`: run RuboCop
 
-- Engineering leadership, coaching, and hiring (including Staff+)
-- Lean/agile ways of working (Kanban, continuous improvement, no-blame retrospectives)
-- Technical strategy and architecture (microservices, DDD, APIs, C4, RFCs/ADRs)
-- Developer Experience and delivery (CI/CD, release management, documentation, productivity metrics)
-- Reliability and operations (SRE, incident management, observability, fault tolerance, security)
-- Cloud and platform tooling (Kubernetes, IaC, AWS/GCP; working with vendors like Datadog/Confluent)
-- Distributed systems patterns (event-driven architecture, Kafka/RabbitMQ; shared libraries)
-- Continuous learning and craftsmanship (BDD/specification by example, reading/writing, OSS)
-- Audio technology
+## Content
+
+- `_includes/home.md`: homepage content
+- `index.md`: homepage wrapper
+- `_config.yml`: Jekyll and theme configuration
+- `_includes/head-custom.html`: favicon and manifest links
+- `assets/images/`: favicons and web manifest assets
+- `robots.txt`: crawler policy

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,6 @@ defaults:
 # Basic defaults expected by Beautiful Jekyll (safe to tweak later)
 navbar-links:
   Home: "/"
-  README: "/"
 
 # If you want a logo/avatar later, point it to a real path under `assets/`
 # avatar: "/assets/images/avatar.png"

--- a/_includes/home.md
+++ b/_includes/home.md
@@ -1,0 +1,28 @@
+# Alejandro Falkowski
+
+Software leadership, reliable systems, and product delivery.
+
+I focus on building reliable, high-performing systems and teams. I enjoy working where product ambiguity, technical depth, and team design meet: taking ideas to production, improving existing platforms, and collaborating closely with stakeholders to ship measurable outcomes.
+
+## Connect
+
+- [CV](https://docs.google.com/document/d/1Nd9rfwKs_j5rcImtY17WhFj4LDfnHSRY_lgnh5cCjeE/edit?usp=sharing)
+- [LinkedIn](https://www.linkedin.com/in/alejandro-falkowski/)
+- [GitHub](https://github.com/alexfalkowski)
+- [Blog](https://alejandrofalkowski.substack.com/)
+- [Manager README](https://docs.google.com/document/d/1IR8zKf5e323wEFd8skONK2ruAHWHethVwaXaUcf-NUU/edit?usp=sharing)
+
+## Focus Areas
+
+- Engineering leadership, coaching, and hiring (including Staff+)
+- Product-minded engineering (discovery, delivery tradeoffs, stakeholder alignment, measurable outcomes)
+- Technical strategy and architecture (service design, domain modelling, APIs, C4, RFCs/ADRs)
+- Developer experience and engineering quality (CI/CD, testing strategy, documentation, maintainability)
+- Reliability and operations (SRE, incident management, observability, resilience, security)
+- Cloud and platform engineering (orchestration, infrastructure as code, developer platforms, vendor evaluation)
+- Distributed systems patterns (event-driven architecture, messaging, streaming, shared libraries)
+- Continuous learning and craftsmanship (BDD/specification by example, reading/writing, OSS)
+
+## Also
+
+- Audio technology, production, and creative tooling

--- a/index.md
+++ b/index.md
@@ -3,4 +3,4 @@ layout: home
 share-description: "Software leader focused on building reliable, high-performing systems and teams."
 ---
 
-{% include_relative README.md %}
+{% include home.md %}


### PR DESCRIPTION
## What
- move public homepage content into _includes/home.md
- turn README.md into repository documentation with development and content pointers
- update index.md, AGENTS.md, and the navbar config to reflect the new content split

## Why
- keep the repository README focused on project maintenance instead of serving as public page copy
- make homepage edits easier to find without publishing source documentation as standalone pages
- remove the duplicate README navigation item now that README.md is not a public page

## Testing
- make lint
- bundle exec jekyll build
- inspected generated _site/index.html and confirmed README.md / _includes/home.md are not published as standalone pages

AI-assisted-by: [Codex](https://openai.com/codex/)
