### PR TITLE
build(ci): run security scan and use ruby 4.0.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
           paths:
             - vendor
       - run: make lint
+      - run: make sec
     resource_class: arm.large
   sync:
     docker:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4.1" # Not needed with a .ruby-version file
+          ruby-version: "4.0.4" # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages


### PR DESCRIPTION
## What

- Add `make sec` to CircleCI build validation after linting.
- Update the GitHub Pages workflow Ruby version from `3.4.1` to `4.0.4`.

## Why

- Ensure the repository security scan runs in regular validation.
- Keep the Pages build on the current supported Ruby patch release while preserving `ruby/setup-ruby@v1` for managed action updates.

## Testing

- `git diff --check` - passed
- `make lint` - passed
- `make sec` - passed
- `bundle exec jekyll build` - passed
