### PR TITLE
build(project): validate rendered site in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
             - alexfalkowski-ruby-cache-
       - run: make dep
       - run: make clean-dep
+      - run: make build
       - save_cache:
           name: save deps
           key: alexfalkowski-ruby-cache-{{ checksum "Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ include bin/build/make/help.mak
 include bin/build/make/ruby.mak
 include bin/build/make/git.mak
 
+# Build the site.
+build:
+	JEKYLL_ENV=production bundle exec jekyll build --baseurl ""
+
 # Serve the site.
 serve:
 	bundle exec jekyll serve


### PR DESCRIPTION
## What

- Add a `build` Make target that renders the Jekyll site in production mode.
- Run the site render in CircleCI after dependencies are installed and before lint/security checks.

## Why

- The rendered site is the primary artifact, but the existing CircleCI validation did not exercise Jekyll rendering before the Pages deploy workflow.
- Running the render earlier catches broken templates, configuration, or remote theme integration before changes reach the deploy path.

## Testing

- `zsh -lic 'gmake build'` - passed with network access for the remote theme download.
- `zsh -lic 'gmake lint'` - passed.
