### PR TITLE
docs(agents): align site build guidance

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: make build baseurl="${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,10 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
   - `make serve`: run the local Jekyll server through the shared Ruby target.
   - `make dep`: install repository dependencies.
   - `make clean-dep`: clean unused dependencies.
+  - `make build`: build the production Jekyll site. Set `baseurl=<path>` when
+    matching the GitHub Pages deployment path.
   - `make lint`: run repository linting.
+  - `make sec`: run repository security checks.
   - `make fix-lint` or `make format`: apply supported lint fixes/formatting.
   - `make source-key`: generate `.source-key` for CI cache keys.
 
@@ -45,7 +48,9 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 ## CI
 
 - CircleCI config is in `.circleci/config.yml`.
-- `build` runs submodule sync/init, `make source-key`, dependency restore/install/clean, and `make lint`.
+- `build` runs submodule sync/init, `make source-key`, dependency restore/install/clean, `make build`, `make lint`, and `make sec`.
+- GitHub Pages deployment is in `.github/workflows/jekyll.yml` and calls
+  `make build baseurl=<pages path>`.
 - Additional workflows run `make sync push` on non-`master` branches and `version` / `package` on `master`.
 
 ## Gotchas

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ include bin/build/make/help.mak
 include bin/build/make/ruby.mak
 include bin/build/make/git.mak
 
+baseurl ?=
+
 # Build the site.
 build:
-	JEKYLL_ENV=production bundle exec jekyll build --baseurl ""
+	JEKYLL_ENV=production bundle exec jekyll build --baseurl "$(baseurl)"
 
 # Serve the site.
 serve:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ The site is built with Jekyll and the Beautiful Jekyll remote theme. Public home
 
 - `make`: show available targets
 - `make dep`: install Ruby dependencies into `vendor/bundle`
+- `make build`: build the production Jekyll site
 - `make serve`: run the local Jekyll server
 - `make lint`: run RuboCop
+- `make sec`: run repository security checks
 
 ## Content
 


### PR DESCRIPTION
Use the local build target from GitHub Pages and document the CI validation commands.
